### PR TITLE
Use version 5 of the API

### DIFF
--- a/lib/finapps_core/rest/defaults.rb
+++ b/lib/finapps_core/rest/defaults.rb
@@ -5,7 +5,7 @@ require 'logger'
 module FinAppsCore
   module REST
     module Defaults
-      API_VERSION = '4'
+      API_VERSION = '5'
 
       # noinspection SpellCheckingInspection
       DEFAULTS = {

--- a/spec/rest/defaults_spec.rb
+++ b/spec/rest/defaults_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FinAppsCore::REST::Defaults do
   describe 'set constants' do
     before { stub_const(described_class.to_s, fake_class) }
 
-    it('sets API_VERSION') { expect(described_class::API_VERSION).to eq '4' }
+    it('sets API_VERSION') { expect(described_class::API_VERSION).to eq '5' }
     it('sets DEFAULTS') { expect(described_class::DEFAULTS).to be_a(Hash) }
     it('freezes DEFAULTS') { expect(described_class::DEFAULTS).to be_frozen }
 


### PR DESCRIPTION
Update constants to use v5 of the Go API.